### PR TITLE
set the sources of products created to woo

### DIFF
--- a/src/Adapters/ProductAdapter.php
+++ b/src/Adapters/ProductAdapter.php
@@ -18,7 +18,7 @@ class ProductAdapter {
 
 		$response = array(
 			'reference' => $this->product->get_id(),
-			'source': 'woo',
+			'source' => 'woo',
 			'type' => 'product',
 			'name' => $this->product->get_name(),
 			'categories' => wp_get_post_terms( $this->product->get_id(), 'product_cat', array( 'fields' => 'names' ) ),

--- a/src/Adapters/ProductAdapter.php
+++ b/src/Adapters/ProductAdapter.php
@@ -18,6 +18,7 @@ class ProductAdapter {
 
 		$response = array(
 			'reference' => $this->product->get_id(),
+			'source': 'woo',
 			'type' => 'product',
 			'name' => $this->product->get_name(),
 			'categories' => wp_get_post_terms( $this->product->get_id(), 'product_cat', array( 'fields' => 'names' ) ),

--- a/tests/Unit/Adapters/ProductAdapterTest.php
+++ b/tests/Unit/Adapters/ProductAdapterTest.php
@@ -21,6 +21,7 @@ test('returns the correct structure', function () {
 
     expect($result)->toBeArray();
     expect($result)->toHaveKey('reference');
+    expect($result)->toHaveKey('source');
     expect($result)->toHaveKey('type');
     expect($result)->toHaveKey('name');
     expect($result)->toHaveKey('currency');
@@ -32,6 +33,12 @@ test('has the correct type', function () {
     $result = (new ProductAdapter($this->product))->get();
 
     expect($result['type'])->toBe('product');
+});
+
+test('has the correct source', function () {
+    $result = (new ProductAdapter($this->product))->get();
+
+    expect($result['source'])->toBe('woo');
 });
 
 test('finds the correct product if passed an ID', function () {
@@ -48,4 +55,3 @@ test('sets the quantity if item is passed', function () {
 
     expect($result['quantity'])->toBe(2);
 });
-


### PR DESCRIPTION
As we have exposed the `source` column for Products in the API, we should set the source of products created from Woo to `woo` constant. 

This PR adds such support, it sets the `source` of instances created from the product adapter to `woo`, which is accepted in the backend. 