### PR TITLE
Order Adapter Changes

### DIFF
--- a/src/Adapters/OrderAdapter.php
+++ b/src/Adapters/OrderAdapter.php
@@ -20,11 +20,10 @@ class OrderAdapter {
 		}
 
 		return array(
+            'source' => 'woo',
+            'delivery' => 'deliver',
 			'reference' => $this->order->get_id(),
-			'type' => 'order',
-			'products' => ( isset($this->products) && 0 < count($this->products) )
-				? $this->products
-				: $this->adapted_products(),
+			'items' => $this->adapted_products(),
 			'total' => ( new PriceAdapter($this->order->get_total(), $this->order->get_currency()) )->get(),
 		);
 	}
@@ -35,7 +34,10 @@ class OrderAdapter {
 		foreach ($items as $item) {
 			$product = $item->get_product();
 
-			$this->products[] = ( new ProductAdapter($product) )->get();
+            $this->products[] = [
+                'product' => ( new ProductAdapter($product) )->get(),
+                'quantity' => $item->get_quantity(),
+            ];
 		}
 
 		return $this->products;

--- a/src/Adapters/ProductAdapter.php
+++ b/src/Adapters/ProductAdapter.php
@@ -6,11 +6,9 @@ use Hellotext\Adapters\PriceAdapter;
 
 class ProductAdapter {
 	public $product; // WooCommerce product
-	public $item;    // Cart/Order item
 
-	public function __construct ($product, $item = null) {
+	public function __construct ($product) {
 		$this->product = is_numeric($product) ? wc_get_product( $product ) : $product;
-		$this->item = $item;
 	}
 
 	public function get () {
@@ -21,7 +19,6 @@ class ProductAdapter {
 		$response = array(
 			'reference' => $this->product->get_id(),
 			'source' => 'woo',
-			'type' => 'product',
 			'name' => $this->product->get_name(),
 			'categories' => wp_get_post_terms( $this->product->get_id(), 'product_cat', array( 'fields' => 'names' ) ),
 			'price' => ( new PriceAdapter($this->product->get_price()) )->get(),
@@ -29,12 +26,6 @@ class ProductAdapter {
 			'image_url' => wp_get_attachment_url( $this->product->get_image_id() ),
 			'url' => get_permalink( $this->product->get_id() ),
 		);
-
-		if (isset($this->item)) {
-			$response['quantity'] = is_array($this->item)
-				? $this->item['quantity']
-				: $this->item->get_quantity();
-		}
 
 		$response = array_filter($response, function ($value) {
 			return null != $value && [] != $value;

--- a/src/Adapters/RefundAdapter.php
+++ b/src/Adapters/RefundAdapter.php
@@ -23,15 +23,10 @@ class RefundAdapter {
 
 		return array(
 			'reference' => $this->refund->get_id(),
-			'type' => 'refund',
+			'source' => 'woo',
 			'amount' => $this->refund->get_amount(),
 			'currency' => $this->refund->get_currency(),
 			'total' => ( new PriceAdapter($this->order->get_total(), $this->order->get_currency()) )->get(),
-			'refundable' => [
-				'type' => 'order',
-				'amount' => $this->order->get_total(),
-				'currency' => $this->order->get_currency(),
-			]
 		);
 	}
 

--- a/tests/Unit/Adapters/OrderAdapterTest.php
+++ b/tests/Unit/Adapters/OrderAdapterTest.php
@@ -28,44 +28,32 @@ test('returns the correct structure', function () {
 
 	expect($result)->toBeArray();
 	expect($result)->toHaveKey('reference');
-	expect($result)->toHaveKey('type');
-	expect($result)->toHaveKey('products');
+	expect($result)->toHaveKey('items');
 	expect($result)->toHaveKey('total');
-});
-
-test('has the correct type', function () {
-	$result = (new OrderAdapter($this->order))->get();
-
-	expect($result['type'])->toBe('order');
+	expect($result['source'])->toBe('woo');
 });
 
 test('finds the correct order if passed an ID', function () {
 	$result = (new OrderAdapter($this->order->get_id()))->get();
-
 	expect($result['reference'])->toBe($this->order->get_id());
 });
 
-test('has the products array', function () {
+test('has the products array as items', function () {
 	$result = (new OrderAdapter($this->order))->get();
-
-	expect($result['products'])->toBeArray();
+	expect($result['items'])->toBeArray();
 });
 
 test('has the correct amount of products', function () {
 	$result = (new OrderAdapter($this->order))->get();
-
-	expect($result['products'])->toHaveLength(1);
+	expect($result['items'])->toHaveLength(1);
 });
 
 test('products have the correct type', function () {
 	$result = (new OrderAdapter($this->order))->get();
-
-	expect($result['products'][0]['type'])->toBe('product');
+	expect($result['items'][0])->toHaveKey('product');
 });
 
 test('will return the products passed in the constructor', function () {
 	$result = (new OrderAdapter($this->order, ['test']))->get();
-
-	expect($result['products'][0])->toBe('test');
+	expect($result['items'][0])->toBe('test');
 });
-

--- a/tests/Unit/Adapters/ProductAdapterTest.php
+++ b/tests/Unit/Adapters/ProductAdapterTest.php
@@ -22,15 +22,8 @@ test('returns the correct structure', function () {
     expect($result)->toBeArray();
     expect($result)->toHaveKey('reference');
     expect($result)->toHaveKey('source');
-    expect($result)->toHaveKey('type');
     expect($result)->toHaveKey('name');
     expect($result)->toHaveKey('price');
-});
-
-test('has the correct type', function () {
-    $result = (new ProductAdapter($this->product))->get();
-
-    expect($result['type'])->toBe('product');
 });
 
 test('has the correct source', function () {
@@ -43,13 +36,4 @@ test('finds the correct product if passed an ID', function () {
     $result = (new ProductAdapter($this->product->get_id()))->get();
 
     expect($result['name'])->toBe($this->product->get_name());
-});
-
-test('sets the quantity if item is passed', function () {
-    $item = new WC_Order_Item_Product();
-    $item->set_quantity(2);
-
-    $result = (new ProductAdapter($this->product, $item))->get();
-
-    expect($result['quantity'])->toBe(2);
 });

--- a/tests/Unit/Adapters/RefundAdapterTest.php
+++ b/tests/Unit/Adapters/RefundAdapterTest.php
@@ -34,20 +34,6 @@ test('returns the correct structure', function () {
 
 	expect($result)->toBeArray();
 	expect($result)->toHaveKey('reference');
-	expect($result)->toHaveKey('type');
 	expect($result)->toHaveKey('amount');
 	expect($result)->toHaveKey('amount');
-	expect($result)->toHaveKey('refundable');
-});
-
-test('has the correct type', function () {
-	$result = (new RefundAdapter($this->refund, $this->order))->get();
-
-	expect($result['type'])->toBe('refund');
-});
-
-test('the refundable has the correct type', function () {
-	$result = (new RefundAdapter($this->refund, $this->order))->get();
-
-	expect($result['refundable']['type'])->toBe('order');
 });


### PR DESCRIPTION
The Order Adapter was sending the payload in a wrong way not compatible with the Api, this caused order events to be dropped with unprocessable entity since the request format was incorrect. 

This PR addresses this by updating the Order Adapter to include the `items` key alongside quantity and contain the `product` as a key within the `items` array. 