### PR TITLE
Session Attaching

### DIFF
--- a/src/Services/CreateProfile.php
+++ b/src/Services/CreateProfile.php
@@ -69,6 +69,11 @@ class CreateProfile {
 				update_user_meta($this->user->ID, 'hellotext_profile_id', $profile);
 			}
 
+            $this->client::patch("/sessions/{$this->session}", array(
+               'session' => $this->session,
+               'profile' => $response['body']['id'],
+            ));
+
 			return;
 		}
 


### PR DESCRIPTION
Whenever an event is tracked for a profile, we attempt to attach the hello session to the profile via `PATH v1/sessions/:id`. While this works in the cases the client was a guest who performed an action tracked back to Hellotext, this does not work in the cases where the the client registers first (which would create the profile on Hellotext), and then performs actions. 

Because the session assignment only happens when the Hellotext profile has not yet been created. It will not successfully attach sessions to clients who registered prior to performing events. 

This PR adjusts the `create_profile` function to always PATCH to the respective endpoint whenever an event occurs as well. This way, we can attach sessions that have not yet been created for registered users. 