### PR TITLE
Currency to API

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 ** Hellotext for WooCommerce Changelog **
 
+2025-04-9 - version 1.2.1
+
+* Passes the shop's currency to Hellotext API when the plugin is installed.
+
 2025-03-03 - version 1.2.0
 
 * Updates API structure to the new format.

--- a/src/Events/AppInstalled.php
+++ b/src/Events/AppInstalled.php
@@ -47,6 +47,7 @@ add_action('hellotext_create_integration', function ($business_id) {
                     'email' => get_bloginfo('admin_email'),
                     'consumer_key' => $api_keys->consumer_key,
                     'consumer_secret' => $api_keys->consumer_secret,
+                    'currency' => get_woocommerce_currency(),
                 ]
             ]);
 


### PR DESCRIPTION
This PR gets the shop's configured currency via `get_woocommerce_currency()` function and sends it to the Hellotext API to correctly associate the shop's currency with the Hellotext account. 

