### PR TITLE
change permission of the API key from read to read_write

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 ** Hellotext for WooCommerce Changelog **
 
+2025-04-10 - version 1.2.2
+
+* The generated Hellotext API key has read/write access to allow Hellotext to subscribe to webhooks.
+
 2025-04-9 - version 1.2.1
 
 * Passes the shop's currency to Hellotext API when the plugin is installed.

--- a/src/Events/AppInstalled.php
+++ b/src/Events/AppInstalled.php
@@ -33,7 +33,7 @@ add_action('hellotext_create_integration', function ($business_id) {
 		$wpdb->insert($api_keys_table, [
 			'user_id' => get_current_user_id(),
 			'description' => 'Hellotext',
-			'permissions' => 'read',
+			'permissions' => 'read_write',
 			'consumer_key' => wc_api_hash($conusmer_key),
 			'consumer_secret' => $api_keys->consumer_secret,
 			'truncated_key' => substr($api_keys->consumer_key, -7),


### PR DESCRIPTION
We're now subscribing from Hellotext to Woo Webhooks, for this purpose the API key's access scope has been changed from `read` to `read_write` to allow Hellotext to create webhook subscriptions.