### PR TITLE
chore(ci): group Dependabot updates into single weekly PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
       prefix: "ci"
       include: "scope"
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns: ["*"]
 
   - package-ecosystem: "composer"
     directory: "/"
@@ -17,3 +20,7 @@ updates:
       prefix: "deps"
       include: "scope"
     open-pull-requests-limit: 5
+    versioning-strategy: "lockfile-only"
+    groups:
+      composer-dev:
+        patterns: ["*"]


### PR DESCRIPTION
## Summary

  - Adds `groups` to both `github-actions` and `composer` Dependabot entries so all updates in each ecosystem are batched into a single weekly PR instead of one per package.
  - Adds `versioning-strategy: lockfile-only` to the Composer entry so Dependabot updates only `composer.lock`, never the constraint ranges in `composer.json`.
  
  ## Why
  
Dependabot was opening one PR per package (#18, #28, #29, #33, #34), causing them to race against each other and against manual lock-refresh PRs like #30.
All Composer deps are dev-only, so there's no value in tracking them individually.
  
  ## Effect
  
  - Next weekly Dependabot run produces one grouped `deps(...)` PR for all Composer dev deps and one grouped `ci(...)` PR for all GitHub Actions updates.
  - Supersedes the pattern that required manual `composer.lock` refresh PRs.
  - No runtime or plugin behavior changes.